### PR TITLE
모바일 사이즈 명함 제작 (세로 버전 제작)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2",
         "react-scripts": "5.0.1",
+        "ts-pattern": "^5.4.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15620,6 +15621,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.4.0.tgz",
+      "integrity": "sha512-hgfOMfjlrARCnYtGD/xEAkFHDXuSyuqjzFSltyQCbN689uNvoQL20TVN2XFcLMjfNuwSsQGU+xtH6MrjIwhwUg==",
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
+    "ts-pattern": "^5.4.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -1,8 +1,10 @@
 import styled from "@emotion/styled";
+import { mediaQuery } from "styles/style";
 
 export const StyledCard = styled("div", {
   shouldForwardProp: prop => !["isVisible"].includes(prop.toString()),
 })<{ isVisible: boolean }>(({ isVisible }) => ({
+  overflow: "visible",
   display: "flex",
   position: "relative",
   width: "100%",
@@ -17,8 +19,14 @@ export const StyledCard = styled("div", {
 export const CardWrap = styled("div", {
   shouldForwardProp: prop => !["isMobile"].includes(prop.toString()),
 })<{ isMobile: boolean }>(({ isMobile }) => ({
-  width: "787.5px",
-  height: "437.5px",
+  width: "100vw",
+  maxWidth: "375px",
+  height: "100vh",
+  maxHeight: "667px",
+  ...mediaQuery("sm", {
+    maxWidth: "787.5px",
+    maxHeight: "437.5px",
+  }),
   perspective: "1200px",
 }));
 export const Button = styled.button({

--- a/src/components/card/front/card-front.constant.ts
+++ b/src/components/card/front/card-front.constant.ts
@@ -9,7 +9,7 @@ export const companyInfo = [
   },
   {
     title: "E-mail",
-    detail: "liw0627@lavarwave.co.kr / dldlsdn0987@naver.com",
+    detail: ["liw0627@lavarwave.co.kr", "dldlsdn0987@naver.com"],
   },
   {
     title: "Address",

--- a/src/components/card/front/card-front.index.tsx
+++ b/src/components/card/front/card-front.index.tsx
@@ -25,23 +25,23 @@ const CardFront = (props: React.HTMLAttributes<HTMLDivElement>) => {
         <h6>㈜라바웨이브</h6>
         <div>
           <div>
-            <h6>서비스 개발팀</h6>
+            <h5>서비스 개발팀</h5>
             <p>Front-End 개발</p>
           </div>
           <h2>이인우</h2>
         </div>
       </StyledCardFront.Body>
       <StyledCardFront.Info>
-        <div className="title">
-          {companyInfo.map(({ title }) => (
-            <p key={title}>{title}</p>
-          ))}
-        </div>
-        <div className="contents">
-          {companyInfo.map(({ detail }) => (
-            <p key={detail}>{detail}</p>
-          ))}
-        </div>
+        {companyInfo.map(({ title, detail }) => (
+          <div key={title}>
+            <div className="title">
+              <p>{title}</p>
+            </div>
+            <div className="contents">
+              <p>{typeof detail === "string" ? detail : detail.join(" / ")}</p>
+            </div>
+          </div>
+        ))}
       </StyledCardFront.Info>
     </StyledCardFront.Root>
   );

--- a/src/components/card/front/card-front.styles.ts
+++ b/src/components/card/front/card-front.styles.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { mediaQuery } from "styles/style";
 
 const Root = styled.div({
   backfaceVisibility: "hidden",
@@ -10,63 +11,117 @@ const Root = styled.div({
   flexDirection: "column",
   gap: "0.375rem",
   backgroundColor: "white",
+  justifyContent: "space-between",
+  ...mediaQuery("sm", {
+    justifyContent: "end",
+  }),
 });
 // #DB1F29
 const Header = styled.section({
-  display: "flex",
+  ...mediaQuery("sm", {
+    display: "flex",
+    a: {
+      fontSize: "1.125rem",
+      marginTop: "0.5rem",
+      height: "fit-content",
+      color: "rgba(0, 0, 0, 0.6)",
+    },
+  }),
+
   justifyContent: "space-between",
   a: {
-    fontSize: "1.125rem",
-    marginTop: "0.5rem",
     height: "fit-content",
     color: "rgba(0, 0, 0, 0.6)",
   },
 });
 const Body = styled.section({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "end",
-  marginBottom: "1.25rem",
   h6: {
-    fontSize: "1.25rem",
+    display: "none",
   },
-  p: {
+  h5: {
     fontSize: "1rem",
   },
-  h2: { letterSpacing: "0.5rem", fontSize: "2.75rem", marginRight: "-0.5rem" },
-  "& > div": {
-    gap: "1.25rem",
-    display: "flex",
-    alignItems: "end",
-    "& > div": {
-      display: "flex",
-      alignItems: "end",
-      gap: "0.5rem",
-    },
+  p: {
+    fontSize: ".75rem",
   },
-});
-const Info = styled.section({
-  display: "flex",
-  gap: "1.25rem",
-  "& > div": {
+  h2: {
+    letterSpacing: "0.5rem",
+    fontSize: "2rem",
+    marginRight: "-0.5rem",
+  },
+  ...mediaQuery("sm", {
     display: "flex",
-    flexDirection: "column",
-    paddingTop: "1.5rem",
-    gap: "0.75rem",
-    p: {
+    justifyContent: "space-between",
+    alignItems: "end",
+    marginBottom: "1.25rem",
+    h6: {
+      display: "block",
       fontSize: "1.25rem",
     },
-  },
-  "& > div.title": {
-    borderTop: "3px solid #DB1F29",
-    color: "#DB1F29",
+    h5: {
+      fontSize: "1.25rem",
+    },
     p: {
-      fontWeight: 600,
+      fontSize: "1rem",
+    },
+    h2: {
+      fontSize: "2.75rem",
+      marginRight: "-0.5rem",
+    },
+    div: {
+      display: "flex",
+      alignItems: "end",
+    },
+    "& > div": {
+      gap: "1.25rem",
+      "& > div": {
+        gap: "0.5rem",
+      },
+    },
+  }),
+});
+const Info = styled.section({
+  borderTop: "2px solid rgba(0,0,0,0.24)",
+  "& > div": {
+    paddingTop: "0.5rem",
+
+    "& > div.title": {
+      color: "#DB1F29",
+      p: {
+        fontWeight: 600,
+      },
+    },
+    "& > div.contents": {
+      width: "100%",
     },
   },
-  "& > div.contents": {
-    borderTop: "3px solid rgba(0, 0, 0, 0.24)",
-    width: "100%",
-  },
+  ...mediaQuery("sm", {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    borderTop: "none",
+    "& > div": {
+      display: "flex",
+      gap: "1.25rem",
+      p: {
+        fontSize: "1.25rem",
+      },
+      "& > div.title": {
+        width: "12.5%",
+      },
+      ":first-of-type": {
+        paddingTop: 0,
+        "& > div": {
+          paddingTop: "1.5rem",
+        },
+        "& > div.title": {
+          borderTop: "3px solid #DB1F29",
+        },
+        "& > div.contents": {
+          borderTop: "3px solid rgba(0, 0, 0, 0.24)",
+        },
+      },
+    },
+  }),
 });
 export const StyledCardFront = { Root, Header, Body, Info };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -82,6 +82,9 @@
 html,
 body,
 #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
   height: 100%;
 }
 body {
@@ -91,7 +94,7 @@ body {
 }
 
 .app {
-  height: 100%;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/styles/style.ts
+++ b/src/styles/style.ts
@@ -1,0 +1,15 @@
+import { CSSObject } from "@emotion/react";
+
+export const screenSize = {
+  xs: 320,
+  sm: 600,
+  md: 840,
+  lg: 1029,
+  "2xl": 1440,
+};
+export const mediaQuery = (
+  size: keyof typeof screenSize,
+  css: CSSObject
+): CSSObject => ({
+  [`@media (min-width:${screenSize[size]}px)`]: css,
+});


### PR DESCRIPTION
- mediaQuery 스타일 함수 제작
- 모바일 버전일 경우 명함 세로버전으로 렌더링
- ts-pattern 추가
- front-constant 내 email 값 배열로 변경
- info쪽 렌더링 구조 리팩토링 (반복문(map)을 두 번 돌리는 건 비효율적인 것 같아보여 수정)
- 전체 global CSS 내 html 태그 height,width css 변경
- 전체 global css 내 app 클래스 최소 height 설정